### PR TITLE
Reduce mobile navigation spacing and sizing

### DIFF
--- a/src/components/EnhancedMobileBottomNavigation.tsx
+++ b/src/components/EnhancedMobileBottomNavigation.tsx
@@ -264,7 +264,8 @@ export const EnhancedMobileBottomNavigation = ({
     <motion.div
       className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-3 py-1.5 z-50"
       style={{
-        paddingBottom: "max(0.375rem, env(safe-area-inset-bottom))",
+        paddingBottom:
+          "max(1.5rem, calc(env(safe-area-inset-bottom) + 0.75rem))",
       }}
       initial={{ y: 100 }}
       animate={{ y: 0 }}

--- a/src/components/EnhancedMobileBottomNavigation.tsx
+++ b/src/components/EnhancedMobileBottomNavigation.tsx
@@ -262,10 +262,9 @@ export const EnhancedMobileBottomNavigation = ({
 
   return (
     <motion.div
-      className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-3 py-1.5 z-50"
+      className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-3 py-2 z-50"
       style={{
-        paddingBottom:
-          "max(1.5rem, calc(env(safe-area-inset-bottom) + 0.75rem))",
+        paddingBottom: "max(2rem, calc(env(safe-area-inset-bottom) + 1rem))",
       }}
       initial={{ y: 100 }}
       animate={{ y: 0 }}

--- a/src/components/EnhancedMobileBottomNavigation.tsx
+++ b/src/components/EnhancedMobileBottomNavigation.tsx
@@ -181,7 +181,7 @@ export const EnhancedMobileBottomNavigation = ({
 
     return (
       <motion.button
-        className={`relative flex flex-col items-center justify-center p-2 rounded-xl transition-all duration-200 ${
+        className={`relative flex flex-col items-center justify-center p-1.5 rounded-lg transition-all duration-200 ${
           isActive ? "bg-gray-100" : "hover:bg-gray-50"
         }`}
         onClick={() => handleTabPress(item.id)}
@@ -207,7 +207,7 @@ export const EnhancedMobileBottomNavigation = ({
           >
             <Badge
               variant="destructive"
-              className="h-5 w-5 p-0 flex items-center justify-center text-xs rounded-full"
+              className="h-4 w-4 p-0 flex items-center justify-center text-xs rounded-full"
             >
               {badgeCount > 9 ? "9+" : badgeCount}
             </Badge>
@@ -217,19 +217,19 @@ export const EnhancedMobileBottomNavigation = ({
         {/* Icon */}
         <motion.div
           animate={{
-            scale: isActive ? 1.15 : 1,
-            rotate: isActive ? [0, -8, 8, 0] : 0,
+            scale: isActive ? 1.1 : 1,
+            rotate: isActive ? [0, -6, 6, 0] : 0,
           }}
           transition={{ duration: 0.3 }}
         >
           <Icon
-            className={`h-6 w-6 ${isActive ? item.activeColor : item.inactiveColor}`}
+            className={`h-5 w-5 ${isActive ? item.activeColor : item.inactiveColor}`}
           />
         </motion.div>
 
         {/* Label */}
         <span
-          className={`text-xs mt-1.5 font-medium transition-colors leading-none ${
+          className={`text-xs mt-1 font-medium transition-colors leading-none ${
             isActive ? item.activeColor : item.inactiveColor
           }`}
         >
@@ -251,7 +251,7 @@ export const EnhancedMobileBottomNavigation = ({
             initial={{ opacity: 0, scale: 0 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0 }}
-            className="absolute -top-12 left-1/2 transform -translate-x-1/2 bg-black text-white text-xs py-1 px-2 rounded"
+            className="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-black text-white text-xs py-1 px-2 rounded"
           >
             Quick actions
           </motion.div>
@@ -262,16 +262,16 @@ export const EnhancedMobileBottomNavigation = ({
 
   return (
     <motion.div
-      className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-2 pb-6 z-50"
+      className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-3 py-1.5 z-50"
       style={{
-        paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))",
+        paddingBottom: "max(0.375rem, env(safe-area-inset-bottom))",
       }}
       initial={{ y: 100 }}
       animate={{ y: 0 }}
       transition={{ type: "spring", stiffness: 300, damping: 30 }}
     >
       {/* Enhanced Layout: 2 items - Large Add Button - 2 items */}
-      <div className="flex items-center justify-between px-2 pt-2">
+      <div className="flex items-center justify-between px-1 pt-1">
         {/* Left Section - Home & People */}
         <div className="flex flex-1 justify-around">
           {navigationItems.slice(0, 2).map((item) => (
@@ -280,7 +280,7 @@ export const EnhancedMobileBottomNavigation = ({
         </div>
 
         {/* Center - Enhanced Quick Action Button */}
-        <div className="flex-shrink-0 mx-6 relative">
+        <div className="flex-shrink-0 mx-4 relative">
           {/* Expanded Actions */}
           <AnimatePresence>
             {isExpanded && (
@@ -288,7 +288,7 @@ export const EnhancedMobileBottomNavigation = ({
                 initial={{ opacity: 0, scale: 0.8 }}
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.8 }}
-                className="absolute bottom-16 left-1/2 transform -translate-x-1/2 space-y-3"
+                className="absolute bottom-14 left-1/2 transform -translate-x-1/2 space-y-2"
               >
                 {quickActions.map((action, index) => {
                   const ActionIcon = action.icon;
@@ -303,9 +303,9 @@ export const EnhancedMobileBottomNavigation = ({
                       }}
                       exit={{ opacity: 0, y: 20 }}
                       onClick={() => handleQuickAction(action.id)}
-                      className={`${action.color} text-white p-3 rounded-full shadow-lg flex items-center gap-2 pr-4 hover:shadow-xl transition-shadow whitespace-nowrap`}
+                      className={`${action.color} text-white p-2.5 rounded-full shadow-lg flex items-center gap-2 pr-3 hover:shadow-xl transition-shadow whitespace-nowrap`}
                     >
-                      <ActionIcon className="h-5 w-5" />
+                      <ActionIcon className="h-4 w-4" />
                       <span className="text-sm font-medium">
                         {action.label}
                       </span>
@@ -328,12 +328,12 @@ export const EnhancedMobileBottomNavigation = ({
             }}
           />
           <motion.button
-            className="relative bg-gradient-to-r from-green-500 to-emerald-600 text-white p-4 rounded-full shadow-lg"
+            className="relative bg-gradient-to-r from-green-500 to-emerald-600 text-white p-3 rounded-full shadow-lg"
             whileTap={{ scale: 0.9 }}
             whileHover={{ scale: 1.05 }}
             style={{
               boxShadow:
-                "0 8px 25px rgba(34, 197, 94, 0.3), 0 4px 12px rgba(0, 0, 0, 0.15)",
+                "0 6px 20px rgba(34, 197, 94, 0.3), 0 3px 10px rgba(0, 0, 0, 0.15)",
             }}
             onClick={() => setIsExpanded(!isExpanded)}
             animate={{
@@ -342,9 +342,9 @@ export const EnhancedMobileBottomNavigation = ({
             transition={{ duration: 0.2 }}
           >
             {isExpanded ? (
-              <X className="h-7 w-7" />
+              <X className="h-6 w-6" />
             ) : (
-              <Plus className="h-7 w-7" />
+              <Plus className="h-6 w-6" />
             )}
           </motion.button>
         </div>
@@ -358,8 +358,8 @@ export const EnhancedMobileBottomNavigation = ({
       </div>
 
       {/* Home indicator for iPhone-like devices */}
-      <div className="flex justify-center pt-3 pb-1">
-        <div className="w-36 h-1 bg-gray-300 rounded-full opacity-60"></div>
+      <div className="flex justify-center pt-2 pb-1">
+        <div className="w-32 h-1 bg-gray-300 rounded-full opacity-60"></div>
       </div>
 
       {/* Backdrop */}

--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -56,7 +56,7 @@ export const MobileLayout = ({
         className="absolute inset-0 overflow-y-auto content-scroll"
         style={{
           top: "60px", // Header height
-          bottom: "88px", // Bottom nav height + safe area
+          bottom: "72px", // Reduced bottom nav height + safe area
           paddingBottom: "env(safe-area-inset-bottom, 0px)",
         }}
       >

--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -56,8 +56,8 @@ export const MobileLayout = ({
         className="absolute inset-0 overflow-y-auto content-scroll"
         style={{
           top: "60px", // Header height
-          bottom: "72px", // Reduced bottom nav height + safe area
-          paddingBottom: "env(safe-area-inset-bottom, 0px)",
+          bottom: "max(88px, calc(env(safe-area-inset-bottom) + 72px))", // Navigation height + safe area
+          paddingBottom: "0px",
         }}
       >
         <div className="p-4">{children}</div>

--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -56,7 +56,7 @@ export const MobileLayout = ({
         className="absolute inset-0 overflow-y-auto content-scroll"
         style={{
           top: "60px", // Header height
-          bottom: "max(88px, calc(env(safe-area-inset-bottom) + 72px))", // Navigation height + safe area
+          bottom: "max(96px, calc(env(safe-area-inset-bottom) + 80px))", // Navigation height + safe area
           paddingBottom: "0px",
         }}
       >

--- a/src/components/RelationshipDetail.tsx
+++ b/src/components/RelationshipDetail.tsx
@@ -152,345 +152,249 @@ export const RelationshipDetail = () => {
   const balanceStatus = getBalanceStatus();
 
   return (
-    <div className="space-y-6">
-      {/* Relationship Header */}
-      <div className="bg-white rounded-lg p-4 shadow-sm">
-        <div className="flex items-center gap-3 mb-2">
-          <h1 className="text-xl font-bold text-gray-900">
-            {relationship.name}
-          </h1>
-          <Badge
-            className={getImportanceColor(relationship.importance_level || 3)}
-          >
-            {getImportanceLabel(relationship.importance_level || 3)}
-          </Badge>
+    <div className="h-full overflow-y-auto">
+      <div className="space-y-6">
+        {/* Relationship Header */}
+        <div className="bg-white rounded-lg p-4 shadow-sm">
+          <div className="flex items-center gap-3 mb-2">
+            <h1 className="text-xl font-bold text-gray-900">
+              {relationship.name}
+            </h1>
+            <Badge
+              className={getImportanceColor(relationship.importance_level || 3)}
+            >
+              {getImportanceLabel(relationship.importance_level || 3)}
+            </Badge>
+          </div>
+          <p className="text-gray-600 capitalize">
+            {relationship.relationship_type.replace("_", " ")}
+          </p>
         </div>
-        <p className="text-gray-600 capitalize">
-          {relationship.relationship_type.replace("_", " ")}
-        </p>
-      </div>
 
-      {/* Balance Card */}
-      <Card>
-        <CardContent className="pt-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="font-semibold text-gray-900 mb-1">
-                Relationship Balance
-              </h3>
-              <p className={`text-sm ${balanceStatus.color}`}>
-                {balanceStatus.label}
-              </p>
-            </div>
-            <div className={`px-4 py-2 rounded-lg ${balanceStatus.bg}`}>
-              <div className="text-center">
-                <div className="text-2xl font-bold text-gray-900">
-                  {balance > 0 ? `+${balance}` : balance}
+        {/* Balance Card */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold text-gray-900 mb-1">
+                  Relationship Balance
+                </h3>
+                <p className={`text-sm ${balanceStatus.color}`}>
+                  {balanceStatus.label}
+                </p>
+              </div>
+              <div className={`px-4 py-2 rounded-lg ${balanceStatus.bg}`}>
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-gray-900">
+                    {balance > 0 ? `+${balance}` : balance}
+                  </div>
+                  <div className="text-xs text-gray-600">Balance</div>
                 </div>
-                <div className="text-xs text-gray-600">Balance</div>
               </div>
             </div>
-          </div>
-          <div className="grid grid-cols-2 gap-4 mt-4">
-            <div className="text-center p-3 bg-green-50 rounded-lg">
-              <div className="text-xl font-bold text-green-600">
-                {givenFavors.length}
-              </div>
-              <div className="text-xs text-gray-600">Given</div>
-            </div>
-            <div className="text-center p-3 bg-blue-50 rounded-lg">
-              <div className="text-xl font-bold text-blue-600">
-                {receivedFavors.length}
-              </div>
-              <div className="text-xs text-gray-600">Received</div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Quick Actions */}
-      <div className="flex gap-3">
-        <Button
-          className="flex-1"
-          variant="outline"
-          onClick={() => {
-            // You could implement a quick add favor modal here
-            // or navigate to add favor with pre-filled relationship
-            toast({
-              title: "Add Favor",
-              description:
-                "Navigate to the main page to add a favor for this relationship.",
-            });
-          }}
-        >
-          <Heart className="h-4 w-4 mr-2" />
-          Add Favor
-        </Button>
-        <Button
-          className="flex-1"
-          variant="outline"
-          onClick={() => {
-            // Handle contact action
-            toast({
-              title: "Contact",
-              description: "Contact functionality can be implemented here.",
-            });
-          }}
-        >
-          <MessageCircle className="h-4 w-4 mr-2" />
-          Contact
-        </Button>
-        <Button
-          onClick={handleGenerateRecommendations}
-          disabled={loadingRecommendations}
-          className="bg-purple-600 hover:bg-purple-700"
-        >
-          <Bot className="h-4 w-4 mr-2" />
-          {loadingRecommendations ? "Generating..." : "AI Insights"}
-        </Button>
-      </div>
-
-      {/* Tabs */}
-      <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value="history">Favor History</TabsTrigger>
-          <TabsTrigger value="recommendations">AI Recommendations</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="history" className="space-y-4">
-          {favors.length === 0 ? (
-            <Card>
-              <CardContent className="pt-6">
-                <div className="text-center text-gray-500 py-8">
-                  <Gift className="h-12 w-12 mx-auto mb-4 text-gray-300" />
-                  <p className="font-semibold">No favor history yet</p>
-                  <p className="text-sm">
-                    Start by adding your first favor with {relationship.name}.
-                  </p>
+            <div className="grid grid-cols-2 gap-4 mt-4">
+              <div className="text-center p-3 bg-green-50 rounded-lg">
+                <div className="text-xl font-bold text-green-600">
+                  {givenFavors.length}
                 </div>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className="space-y-3">
-              {favors.map((favor) => (
-                <Card
-                  key={favor.id}
-                  className="hover:shadow-sm transition-shadow"
-                >
-                  <CardContent className="pt-4">
-                    <div className="flex items-start justify-between">
-                      <div className="flex-1">
-                        <div className="flex items-center gap-2 mb-2">
-                          <Badge
-                            variant={
-                              favor.direction === "given"
-                                ? "default"
-                                : "secondary"
-                            }
-                            className="text-xs"
-                          >
-                            {favor.direction === "given" ? "Given" : "Received"}
-                          </Badge>
-                          <span className="text-xs text-gray-500 capitalize">
-                            {favor.category}
-                          </span>
-                        </div>
-                        <p className="text-sm text-gray-900 mb-1">
-                          {favor.description}
-                        </p>
-                        <div className="flex items-center gap-2 text-xs text-gray-500">
-                          <Calendar className="h-3 w-3" />
-                          {format(new Date(favor.date_occurred), "MMM d, yyyy")}
-                          {favor.emotional_weight && (
-                            <>
-                              <span>•</span>
-                              <span>Weight: {favor.emotional_weight}/5</span>
-                            </>
-                          )}
-                        </div>
-                      </div>
-                      {favor.reciprocated && (
-                        <Badge variant="outline" className="text-xs">
-                          Reciprocated
-                        </Badge>
-                      )}
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
+                <div className="text-xs text-gray-600">Given</div>
+              </div>
+              <div className="text-center p-3 bg-blue-50 rounded-lg">
+                <div className="text-xl font-bold text-blue-600">
+                  {receivedFavors.length}
+                </div>
+                <div className="text-xs text-gray-600">Received</div>
+              </div>
             </div>
-          )}
-        </TabsContent>
+          </CardContent>
+        </Card>
 
-        <TabsContent value="recommendations" className="space-y-4">
-          {/* Generate New Recommendations Button */}
+        {/* Quick Actions */}
+        <div className="flex gap-3">
+          <Button
+            className="flex-1"
+            variant="outline"
+            onClick={() => {
+              // You could implement a quick add favor modal here
+              // or navigate to add favor with pre-filled relationship
+              toast({
+                title: "Add Favor",
+                description:
+                  "Navigate to the main page to add a favor for this relationship.",
+              });
+            }}
+          >
+            <Heart className="h-4 w-4 mr-2" />
+            Add Favor
+          </Button>
+          <Button
+            className="flex-1"
+            variant="outline"
+            onClick={() => {
+              // Handle contact action
+              toast({
+                title: "Contact",
+                description: "Contact functionality can be implemented here.",
+              });
+            }}
+          >
+            <MessageCircle className="h-4 w-4 mr-2" />
+            Contact
+          </Button>
           <Button
             onClick={handleGenerateRecommendations}
             disabled={loadingRecommendations}
-            className="w-full bg-purple-600 hover:bg-purple-700"
+            className="bg-purple-600 hover:bg-purple-700"
           >
             <Bot className="h-4 w-4 mr-2" />
-            {loadingRecommendations
-              ? "Generating..."
-              : "Generate New AI Insights"}
+            {loadingRecommendations ? "Generating..." : "AI Insights"}
           </Button>
+        </div>
 
-          {/* Temporary AI Generated Recommendations */}
-          {recommendations.length > 0 && (
-            <div className="space-y-4">
-              <div className="flex items-center gap-2 mb-2">
-                <Sparkles className="h-4 w-4 text-purple-600" />
-                <h3 className="font-semibold text-gray-900">
-                  New AI Recommendations
-                </h3>
-                <Badge variant="outline" className="text-xs">
-                  Unsaved
-                </Badge>
-              </div>
-              {recommendations.map((rec, index) => (
-                <Card
-                  key={`temp-${index}`}
-                  className="border-purple-200 bg-purple-50/50"
-                >
-                  <CardHeader>
-                    <div className="flex items-start justify-between">
-                      <CardTitle className="text-lg">{rec.title}</CardTitle>
-                      <div className="flex items-center gap-2">
-                        <Badge
-                          variant={
-                            rec.priority_level >= 4
-                              ? "destructive"
-                              : rec.priority_level >= 3
-                                ? "default"
-                                : "secondary"
-                          }
-                        >
-                          {rec.priority_level >= 4
-                            ? "High"
-                            : rec.priority_level >= 3
-                              ? "Medium"
-                              : "Low"}{" "}
-                          Priority
-                        </Badge>
-                        <Button
-                          size="sm"
-                          onClick={() => handleSaveRecommendation(rec, index)}
-                          disabled={isSaving}
-                          className="bg-green-600 hover:bg-green-700"
-                        >
-                          <Save className="h-3 w-3 mr-1" />
-                          Save
-                        </Button>
-                      </div>
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-gray-700 mb-3">{rec.description}</p>
-                    {rec.suggested_actions?.how_to_execute && (
-                      <div className="space-y-2">
-                        <h4 className="font-semibold text-sm text-gray-900">
-                          How to execute:
-                        </h4>
-                        <ul className="text-sm text-gray-600 space-y-1">
-                          {rec.suggested_actions.how_to_execute.map(
-                            (action: string, i: number) => (
-                              <li key={i} className="flex items-start gap-2">
-                                <span className="text-purple-600">��</span>
-                                <span>{action}</span>
-                              </li>
-                            ),
-                          )}
-                        </ul>
-                      </div>
-                    )}
-                    {rec.due_date && (
-                      <div className="mt-3 flex items-center gap-2 text-xs text-gray-500">
-                        <Calendar className="h-3 w-3" />
-                        Due: {format(new Date(rec.due_date), "MMM d, yyyy")}
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          )}
+        {/* Tabs */}
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="history">Favor History</TabsTrigger>
+            <TabsTrigger value="recommendations">
+              AI Recommendations
+            </TabsTrigger>
+          </TabsList>
 
-          {/* Saved Recommendations */}
-          {savedRecommendations.length > 0 && (
-            <div className="space-y-4">
-              <div className="flex items-center gap-2 mb-2">
-                <Save className="h-4 w-4 text-green-600" />
-                <h3 className="font-semibold text-gray-900">
-                  Saved Recommendations
-                </h3>
-                <Badge variant="outline" className="text-xs">
-                  {savedRecommendations.length} saved
-                </Badge>
-              </div>
-              {savedRecommendations.map((rec) => (
-                <Card key={rec.id} className="border-green-200 bg-green-50/50">
-                  <CardHeader>
-                    <div className="flex items-start justify-between">
-                      <CardTitle className="text-lg flex items-center gap-2">
-                        {rec.title}
-                        {rec.completed && (
-                          <CheckCircle className="h-4 w-4 text-green-600" />
-                        )}
-                      </CardTitle>
-                      <div className="flex items-center gap-2">
-                        <Badge
-                          variant={
-                            rec.priority_level >= 4
-                              ? "destructive"
-                              : rec.priority_level >= 3
-                                ? "default"
-                                : "secondary"
-                          }
-                        >
-                          {rec.priority_level >= 4
-                            ? "High"
-                            : rec.priority_level >= 3
-                              ? "Medium"
-                              : "Low"}{" "}
-                          Priority
-                        </Badge>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() =>
-                            markCompleted({
-                              id: rec.id,
-                              completed: !rec.completed,
-                            })
-                          }
-                          className={rec.completed ? "bg-green-100" : ""}
-                        >
-                          {rec.completed ? (
-                            <X className="h-3 w-3" />
-                          ) : (
-                            <Check className="h-3 w-3" />
-                          )}
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="destructive"
-                          onClick={() => deleteRecommendation(rec.id)}
-                          disabled={isDeleting}
-                        >
-                          <Trash2 className="h-3 w-3" />
-                        </Button>
-                      </div>
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <p
-                      className={`text-gray-700 mb-3 ${rec.completed ? "line-through opacity-60" : ""}`}
-                    >
-                      {rec.description}
+          <TabsContent value="history" className="space-y-4">
+            {favors.length === 0 ? (
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="text-center text-gray-500 py-8">
+                    <Gift className="h-12 w-12 mx-auto mb-4 text-gray-300" />
+                    <p className="font-semibold">No favor history yet</p>
+                    <p className="text-sm">
+                      Start by adding your first favor with {relationship.name}.
                     </p>
-                    {rec.suggested_actions &&
-                      typeof rec.suggested_actions === "object" &&
-                      rec.suggested_actions.how_to_execute && (
+                  </div>
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="space-y-3">
+                {favors.map((favor) => (
+                  <Card
+                    key={favor.id}
+                    className="hover:shadow-sm transition-shadow"
+                  >
+                    <CardContent className="pt-4">
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-2">
+                            <Badge
+                              variant={
+                                favor.direction === "given"
+                                  ? "default"
+                                  : "secondary"
+                              }
+                              className="text-xs"
+                            >
+                              {favor.direction === "given"
+                                ? "Given"
+                                : "Received"}
+                            </Badge>
+                            <span className="text-xs text-gray-500 capitalize">
+                              {favor.category}
+                            </span>
+                          </div>
+                          <p className="text-sm text-gray-900 mb-1">
+                            {favor.description}
+                          </p>
+                          <div className="flex items-center gap-2 text-xs text-gray-500">
+                            <Calendar className="h-3 w-3" />
+                            {format(
+                              new Date(favor.date_occurred),
+                              "MMM d, yyyy",
+                            )}
+                            {favor.emotional_weight && (
+                              <>
+                                <span>•</span>
+                                <span>Weight: {favor.emotional_weight}/5</span>
+                              </>
+                            )}
+                          </div>
+                        </div>
+                        {favor.reciprocated && (
+                          <Badge variant="outline" className="text-xs">
+                            Reciprocated
+                          </Badge>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </TabsContent>
+
+          <TabsContent value="recommendations" className="space-y-4">
+            {/* Generate New Recommendations Button */}
+            <Button
+              onClick={handleGenerateRecommendations}
+              disabled={loadingRecommendations}
+              className="w-full bg-purple-600 hover:bg-purple-700"
+            >
+              <Bot className="h-4 w-4 mr-2" />
+              {loadingRecommendations
+                ? "Generating..."
+                : "Generate New AI Insights"}
+            </Button>
+
+            {/* Temporary AI Generated Recommendations */}
+            {recommendations.length > 0 && (
+              <div className="space-y-4">
+                <div className="flex items-center gap-2 mb-2">
+                  <Sparkles className="h-4 w-4 text-purple-600" />
+                  <h3 className="font-semibold text-gray-900">
+                    New AI Recommendations
+                  </h3>
+                  <Badge variant="outline" className="text-xs">
+                    Unsaved
+                  </Badge>
+                </div>
+                {recommendations.map((rec, index) => (
+                  <Card
+                    key={`temp-${index}`}
+                    className="border-purple-200 bg-purple-50/50"
+                  >
+                    <CardHeader>
+                      <div className="flex items-start justify-between">
+                        <CardTitle className="text-lg">{rec.title}</CardTitle>
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            variant={
+                              rec.priority_level >= 4
+                                ? "destructive"
+                                : rec.priority_level >= 3
+                                  ? "default"
+                                  : "secondary"
+                            }
+                          >
+                            {rec.priority_level >= 4
+                              ? "High"
+                              : rec.priority_level >= 3
+                                ? "Medium"
+                                : "Low"}{" "}
+                            Priority
+                          </Badge>
+                          <Button
+                            size="sm"
+                            onClick={() => handleSaveRecommendation(rec, index)}
+                            disabled={isSaving}
+                            className="bg-green-600 hover:bg-green-700"
+                          >
+                            <Save className="h-3 w-3 mr-1" />
+                            Save
+                          </Button>
+                        </div>
+                      </div>
+                    </CardHeader>
+                    <CardContent>
+                      <p className="text-gray-700 mb-3">{rec.description}</p>
+                      {rec.suggested_actions?.how_to_execute && (
                         <div className="space-y-2">
                           <h4 className="font-semibold text-sm text-gray-900">
                             How to execute:
@@ -498,11 +402,8 @@ export const RelationshipDetail = () => {
                           <ul className="text-sm text-gray-600 space-y-1">
                             {rec.suggested_actions.how_to_execute.map(
                               (action: string, i: number) => (
-                                <li
-                                  key={i}
-                                  className={`flex items-start gap-2 ${rec.completed ? "line-through opacity-60" : ""}`}
-                                >
-                                  <span className="text-green-600">•</span>
+                                <li key={i} className="flex items-start gap-2">
+                                  <span className="text-purple-600">��</span>
                                   <span>{action}</span>
                                 </li>
                               ),
@@ -510,44 +411,155 @@ export const RelationshipDetail = () => {
                           </ul>
                         </div>
                       )}
-                    <div className="mt-3 flex items-center gap-4 text-xs text-gray-500">
                       {rec.due_date && (
-                        <div className="flex items-center gap-1">
+                        <div className="mt-3 flex items-center gap-2 text-xs text-gray-500">
                           <Calendar className="h-3 w-3" />
                           Due: {format(new Date(rec.due_date), "MMM d, yyyy")}
                         </div>
                       )}
-                      <div className="flex items-center gap-1">
-                        <span>
-                          Saved:{" "}
-                          {format(new Date(rec.created_at), "MMM d, yyyy")}
-                        </span>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+
+            {/* Saved Recommendations */}
+            {savedRecommendations.length > 0 && (
+              <div className="space-y-4">
+                <div className="flex items-center gap-2 mb-2">
+                  <Save className="h-4 w-4 text-green-600" />
+                  <h3 className="font-semibold text-gray-900">
+                    Saved Recommendations
+                  </h3>
+                  <Badge variant="outline" className="text-xs">
+                    {savedRecommendations.length} saved
+                  </Badge>
+                </div>
+                {savedRecommendations.map((rec) => (
+                  <Card
+                    key={rec.id}
+                    className="border-green-200 bg-green-50/50"
+                  >
+                    <CardHeader>
+                      <div className="flex items-start justify-between">
+                        <CardTitle className="text-lg flex items-center gap-2">
+                          {rec.title}
+                          {rec.completed && (
+                            <CheckCircle className="h-4 w-4 text-green-600" />
+                          )}
+                        </CardTitle>
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            variant={
+                              rec.priority_level >= 4
+                                ? "destructive"
+                                : rec.priority_level >= 3
+                                  ? "default"
+                                  : "secondary"
+                            }
+                          >
+                            {rec.priority_level >= 4
+                              ? "High"
+                              : rec.priority_level >= 3
+                                ? "Medium"
+                                : "Low"}{" "}
+                            Priority
+                          </Badge>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() =>
+                              markCompleted({
+                                id: rec.id,
+                                completed: !rec.completed,
+                              })
+                            }
+                            className={rec.completed ? "bg-green-100" : ""}
+                          >
+                            {rec.completed ? (
+                              <X className="h-3 w-3" />
+                            ) : (
+                              <Check className="h-3 w-3" />
+                            )}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => deleteRecommendation(rec.id)}
+                            disabled={isDeleting}
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </Button>
+                        </div>
                       </div>
+                    </CardHeader>
+                    <CardContent>
+                      <p
+                        className={`text-gray-700 mb-3 ${rec.completed ? "line-through opacity-60" : ""}`}
+                      >
+                        {rec.description}
+                      </p>
+                      {rec.suggested_actions &&
+                        typeof rec.suggested_actions === "object" &&
+                        rec.suggested_actions.how_to_execute && (
+                          <div className="space-y-2">
+                            <h4 className="font-semibold text-sm text-gray-900">
+                              How to execute:
+                            </h4>
+                            <ul className="text-sm text-gray-600 space-y-1">
+                              {rec.suggested_actions.how_to_execute.map(
+                                (action: string, i: number) => (
+                                  <li
+                                    key={i}
+                                    className={`flex items-start gap-2 ${rec.completed ? "line-through opacity-60" : ""}`}
+                                  >
+                                    <span className="text-green-600">•</span>
+                                    <span>{action}</span>
+                                  </li>
+                                ),
+                              )}
+                            </ul>
+                          </div>
+                        )}
+                      <div className="mt-3 flex items-center gap-4 text-xs text-gray-500">
+                        {rec.due_date && (
+                          <div className="flex items-center gap-1">
+                            <Calendar className="h-3 w-3" />
+                            Due: {format(new Date(rec.due_date), "MMM d, yyyy")}
+                          </div>
+                        )}
+                        <div className="flex items-center gap-1">
+                          <span>
+                            Saved:{" "}
+                            {format(new Date(rec.created_at), "MMM d, yyyy")}
+                          </span>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+
+            {/* Empty State */}
+            {recommendations.length === 0 &&
+              savedRecommendations.length === 0 && (
+                <Card>
+                  <CardContent className="pt-6">
+                    <div className="text-center text-gray-500 py-8">
+                      <Sparkles className="h-12 w-12 mx-auto mb-4 text-gray-300" />
+                      <p className="font-semibold">No recommendations yet</p>
+                      <p className="text-sm">
+                        Generate AI recommendations to get personalized
+                        relationship insights.
+                      </p>
                     </div>
                   </CardContent>
                 </Card>
-              ))}
-            </div>
-          )}
-
-          {/* Empty State */}
-          {recommendations.length === 0 &&
-            savedRecommendations.length === 0 && (
-              <Card>
-                <CardContent className="pt-6">
-                  <div className="text-center text-gray-500 py-8">
-                    <Sparkles className="h-12 w-12 mx-auto mb-4 text-gray-300" />
-                    <p className="font-semibold">No recommendations yet</p>
-                    <p className="text-sm">
-                      Generate AI recommendations to get personalized
-                      relationship insights.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            )}
-        </TabsContent>
-      </Tabs>
+              )}
+          </TabsContent>
+        </Tabs>
+      </div>
     </div>
   );
 };

--- a/src/components/RelationshipDetail.tsx
+++ b/src/components/RelationshipDetail.tsx
@@ -155,26 +155,32 @@ export const RelationshipDetail = () => {
     <div className="h-full overflow-y-auto">
       <div className="space-y-6">
         {/* Relationship Header */}
-        <div className="bg-white rounded-lg p-4 shadow-sm">
-          <div className="flex items-center gap-3 mb-2">
-            <h1 className="text-xl font-bold text-gray-900">
-              {relationship.name}
-            </h1>
-            <Badge
-              className={getImportanceColor(relationship.importance_level || 3)}
-            >
-              {getImportanceLabel(relationship.importance_level || 3)}
-            </Badge>
-          </div>
-          <p className="text-gray-600 capitalize">
-            {relationship.relationship_type.replace("_", " ")}
-          </p>
-        </div>
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-start justify-between">
+              <div className="flex-1">
+                <h1 className="text-xl font-bold text-gray-900 mb-2">
+                  {relationship.name}
+                </h1>
+                <p className="text-gray-600 capitalize">
+                  {relationship.relationship_type.replace("_", " ")}
+                </p>
+              </div>
+              <Badge
+                className={getImportanceColor(
+                  relationship.importance_level || 3,
+                )}
+              >
+                {getImportanceLabel(relationship.importance_level || 3)}
+              </Badge>
+            </div>
+          </CardContent>
+        </Card>
 
         {/* Balance Card */}
         <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
+          <CardContent className="p-6">
+            <div className="flex items-center justify-between mb-4">
               <div>
                 <h3 className="font-semibold text-gray-900 mb-1">
                   Relationship Balance
@@ -183,7 +189,7 @@ export const RelationshipDetail = () => {
                   {balanceStatus.label}
                 </p>
               </div>
-              <div className={`px-4 py-2 rounded-lg ${balanceStatus.bg}`}>
+              <div className={`px-4 py-3 rounded-lg ${balanceStatus.bg}`}>
                 <div className="text-center">
                   <div className="text-2xl font-bold text-gray-900">
                     {balance > 0 ? `+${balance}` : balance}
@@ -192,27 +198,26 @@ export const RelationshipDetail = () => {
                 </div>
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-4 mt-4">
-              <div className="text-center p-3 bg-green-50 rounded-lg">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="text-center p-4 bg-green-50 rounded-lg border border-green-100">
                 <div className="text-xl font-bold text-green-600">
                   {givenFavors.length}
                 </div>
-                <div className="text-xs text-gray-600">Given</div>
+                <div className="text-xs text-gray-600 mt-1">Given</div>
               </div>
-              <div className="text-center p-3 bg-blue-50 rounded-lg">
+              <div className="text-center p-4 bg-blue-50 rounded-lg border border-blue-100">
                 <div className="text-xl font-bold text-blue-600">
                   {receivedFavors.length}
                 </div>
-                <div className="text-xs text-gray-600">Received</div>
+                <div className="text-xs text-gray-600 mt-1">Received</div>
               </div>
             </div>
           </CardContent>
         </Card>
 
         {/* Quick Actions */}
-        <div className="flex gap-3">
+        <div className="grid grid-cols-2 gap-3">
           <Button
-            className="flex-1"
             variant="outline"
             onClick={() => {
               // You could implement a quick add favor modal here
@@ -223,12 +228,12 @@ export const RelationshipDetail = () => {
                   "Navigate to the main page to add a favor for this relationship.",
               });
             }}
+            className="h-12"
           >
             <Heart className="h-4 w-4 mr-2" />
             Add Favor
           </Button>
           <Button
-            className="flex-1"
             variant="outline"
             onClick={() => {
               // Handle contact action
@@ -237,6 +242,7 @@ export const RelationshipDetail = () => {
                 description: "Contact functionality can be implemented here.",
               });
             }}
+            className="h-12"
           >
             <MessageCircle className="h-4 w-4 mr-2" />
             Contact
@@ -244,7 +250,7 @@ export const RelationshipDetail = () => {
           <Button
             onClick={handleGenerateRecommendations}
             disabled={loadingRecommendations}
-            className="bg-purple-600 hover:bg-purple-700"
+            className="bg-purple-600 hover:bg-purple-700 h-12 col-span-2"
           >
             <Bot className="h-4 w-4 mr-2" />
             {loadingRecommendations ? "Generating..." : "AI Insights"}

--- a/src/components/RelationshipDetail.tsx
+++ b/src/components/RelationshipDetail.tsx
@@ -258,10 +258,12 @@ export const RelationshipDetail = () => {
         </div>
 
         {/* Tabs */}
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="history">Favor History</TabsTrigger>
-            <TabsTrigger value="recommendations">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="mt-6">
+          <TabsList className="grid w-full grid-cols-2 h-12">
+            <TabsTrigger value="history" className="text-sm">
+              Favor History
+            </TabsTrigger>
+            <TabsTrigger value="recommendations" className="text-sm">
               AI Recommendations
             </TabsTrigger>
           </TabsList>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -197,7 +197,11 @@ export const Sidebar = ({ isOpen, onClose }: SidebarProps) => {
               stiffness: 300,
               damping: 30,
             }}
-            className="fixed left-0 top-0 bottom-0 w-80 bg-white shadow-2xl z-50 overflow-hidden"
+            className="fixed left-0 top-0 w-80 bg-white shadow-2xl z-50 overflow-hidden"
+            style={{
+              height: "100vh",
+              paddingBottom: "100px",
+            }}
           >
             <div className="flex flex-col h-full">
               {/* Header */}
@@ -242,8 +246,8 @@ export const Sidebar = ({ isOpen, onClose }: SidebarProps) => {
               </div>
 
               {/* Menu Content */}
-              <div className="flex-1 overflow-y-auto">
-                <div className="p-4 space-y-6">
+              <div className="flex-1 overflow-y-auto scrollbar-hide">
+                <div className="p-4 space-y-6 pb-24">
                   {menuSections.map((section, sectionIndex) => (
                     <div key={section.title}>
                       <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -92,7 +92,7 @@ const Index = () => {
   // Landing page untuk user yang belum login
   if (!isAuthenticated) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-green-50 via-blue-50 to-orange-50">
+      <div className="min-h-screen bg-gradient-to-br from-green-50 via-blue-50 to-orange-50 overflow-y-auto">
         <ResponsiveContainer maxWidth="lg" className="py-8 px-4">
           <div className="text-center mb-8">
             <div className="flex items-center justify-center mb-4">


### PR DESCRIPTION
Reduces spacing and sizing throughout the mobile navigation components to create a more compact layout.

Changes include:
- Decreased padding from p-2 to p-1.5 and rounded-xl to rounded-lg for navigation buttons
- Reduced badge size from h-5 w-5 to h-4 w-4
- Scaled down icon sizes from h-6 w-6 to h-5 w-5
- Decreased animation scale values and rotation angles
- Reduced margins and spacing throughout the navigation bar
- Adjusted tooltip positioning from -top-12 to -top-10
- Modified safe area padding calculation for better mobile layout
- Updated bottom navigation container padding and margins
- Reduced quick action button sizes and spacing
- Decreased home indicator width from w-36 to w-32
- Adjusted content area bottom spacing in MobileLayout
- Modified RelationshipDetail layout for better mobile scrolling
- Updated Sidebar height and padding for mobile compatibility
- Added overflow-y-auto to Index page for better mobile scrolling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/af9ab7d5fcf148d6a8a3123cef2da4b7/swoosh-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>af9ab7d5fcf148d6a8a3123cef2da4b7</projectId>-->
<!--<branchName>swoosh-oasis</branchName>-->